### PR TITLE
Bug fix: Negative startPoint at -setPagesAtContentOffset:

### DIFF
--- a/PagedFlowView/PagedFlowView.m
+++ b/PagedFlowView/PagedFlowView.m
@@ -187,7 +187,7 @@
         return;
     //计算_visibleRange
     CGPoint startPoint = CGPointMake(offset.x - _scrollView.frame.origin.x, offset.y - _scrollView.frame.origin.y);
-    CGPoint endPoint = CGPointMake(startPoint.x + self.bounds.size.width, startPoint.y + self.bounds.size.height);
+    CGPoint endPoint = CGPointMake(MAX(0, startPoint.x) + self.bounds.size.width, MAX(0, startPoint.y) + self.bounds.size.height);
     
     
     switch (orientation) {


### PR DESCRIPTION
Scrolling to left at index zero causes to `startPoint` be negative.

So `endIndex` ends up with `[_cells count]` value, calling `[self setPageAtIndex:i]` `[_cells count]` times! (since `startIndex` is 0)

I was having a performance problem with `-setPageAtIndex:` being called over 300 times...
Hope this fixes it
