### PR TITLE
fix:pageIndex or _currentPageIndex may be negative value

### DIFF
--- a/PagedFlowView/PagedFlowView.m
+++ b/PagedFlowView/PagedFlowView.m
@@ -447,10 +447,10 @@
     
     switch (orientation) {
         case PagedFlowViewOrientationHorizontal:
-            pageIndex = floor(_scrollView.contentOffset.x / _pageSize.width);
+            pageIndex = floor(MAX(_scrollView.contentOffset.x, 0) / _pageSize.width);
             break;
         case PagedFlowViewOrientationVertical:
-            pageIndex = floor(_scrollView.contentOffset.y / _pageSize.height);
+            pageIndex = floor(MAX(_scrollView.contentOffset.y, 0) / _pageSize.height);
             break;
         default:
             break;


### PR DESCRIPTION
当你在第一页时 继续往右(horizontal)拉扯时，pageIndex or _currentPageIndex  就有可能是负值，负值不是应该出现的值
